### PR TITLE
Add tests and strengthen error handling

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -34,7 +34,10 @@ var exportCmd = &cobra.Command{
 		}
 		logVerbose("Collection complete")
 
-		content := renderer.RenderHandoff(snapshot, exportFormat)
+		content, err := renderer.RenderHandoff(snapshot, exportFormat)
+		if err != nil {
+			return err
+		}
 
 		if err := os.WriteFile(exportOutput, []byte(content), 0644); err != nil {
 			return fmt.Errorf("failed to write %s: %w", exportOutput, err)

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -27,7 +27,10 @@ var promptCmd = &cobra.Command{
 		}
 		logVerbose("Collection complete")
 
-		output := renderer.RenderPrompt(snapshot, promptFormat)
+		output, err := renderer.RenderPrompt(snapshot, promptFormat)
+		if err != nil {
+			return err
+		}
 		fmt.Print(output)
 		return nil
 	},

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,0 +1,128 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectGitRepo(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	// Add project files
+	os.WriteFile(filepath.Join(dir, "VISION.md"), []byte("# Vision\nTest vision."), 0644)
+	os.WriteFile(filepath.Join(dir, "PLAN.md"), []byte("# Plan\nTest plan."), 0644)
+
+	snap, err := Collect(dir, CollectOptions{})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	if snap.Git.Branch == "" {
+		t.Error("Git.Branch should not be empty in git repo")
+	}
+	if snap.Files.Vision != "# Vision\nTest vision." {
+		t.Errorf("Vision = %q", snap.Files.Vision)
+	}
+	if snap.Files.Plan != "# Plan\nTest plan." {
+		t.Errorf("Plan = %q", snap.Files.Plan)
+	}
+	if snap.DirTree == "" {
+		t.Error("DirTree should not be empty")
+	}
+	if len(snap.RecentLogs) == 0 {
+		t.Error("RecentLogs should not be empty in git repo with commits")
+	}
+	if snap.Timestamp.IsZero() {
+		t.Error("Timestamp should be set")
+	}
+}
+
+func TestCollectNonGitDir(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "VISION.md"), []byte("# Vision"), 0644)
+
+	snap, err := Collect(dir, CollectOptions{})
+	if err != nil {
+		t.Fatalf("Collect should succeed in non-git dir, got: %v", err)
+	}
+
+	if snap.Git.Branch != "" {
+		t.Error("Git.Branch should be empty for non-git dir")
+	}
+	if snap.Files.Vision != "# Vision" {
+		t.Errorf("Vision = %q", snap.Files.Vision)
+	}
+	if len(snap.RecentLogs) != 0 {
+		t.Error("RecentLogs should be empty for non-git dir")
+	}
+}
+
+func TestCollectWithExtraFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "NOTES.md"), []byte("# Notes"), 0644)
+
+	snap, err := Collect(dir, CollectOptions{
+		ExtraFiles: []string{"NOTES.md", "MISSING.md"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	if snap.Files.Extra["NOTES.md"] != "# Notes" {
+		t.Errorf("Extra[NOTES.md] = %q", snap.Files.Extra["NOTES.md"])
+	}
+	if _, ok := snap.Files.Extra["MISSING.md"]; ok {
+		t.Error("MISSING.md should not be in Extra")
+	}
+}
+
+func TestCollectWithExclude(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "logs"), 0755)
+	os.WriteFile(filepath.Join(dir, "logs", "app.log"), []byte("log"), 0644)
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644)
+
+	snap, err := Collect(dir, CollectOptions{
+		Exclude: []string{"logs"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	if snap.DirTree == "" {
+		t.Error("DirTree should not be empty")
+	}
+}
+
+func TestCollectWithDepth(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "a", "b", "c", "d"), 0755)
+	os.WriteFile(filepath.Join(dir, "a", "b", "c", "d", "deep.txt"), []byte("deep"), 0644)
+
+	snap, err := Collect(dir, CollectOptions{Depth: 1})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	// Depth 1 should only show the immediate children
+	if snap.DirTree == "" {
+		t.Error("DirTree should not be empty")
+	}
+}
+
+func TestCollectEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	snap, err := Collect(dir, CollectOptions{})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	if snap.Files.Vision != "" {
+		t.Error("Vision should be empty for empty dir")
+	}
+	if snap.DirTree == "" {
+		t.Error("DirTree should show at least the root directory")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func Load(dir string) (*Config, error) {
 
 	cfg := DefaultConfig()
 	if err := yaml.Unmarshal(data, cfg); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse .handoff.yaml: %w", err)
 	}
 
 	for _, pattern := range cfg.Exclude {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -74,5 +75,66 @@ depth: 5
 	}
 	if cfg.Depth != 5 {
 		t.Errorf("Depth = %d, want 5", cfg.Depth)
+	}
+}
+
+func TestLoadInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".handoff.yaml"), []byte("{{invalid yaml"), 0644)
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("Load should return error for invalid YAML")
+	}
+	if !strings.Contains(err.Error(), "failed to parse .handoff.yaml") {
+		t.Errorf("error should contain context, got: %v", err)
+	}
+}
+
+func TestLoadBadExcludePattern(t *testing.T) {
+	dir := t.TempDir()
+	content := `exclude:
+  - "[invalid"
+`
+	os.WriteFile(filepath.Join(dir, ".handoff.yaml"), []byte(content), 0644)
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("Load should return error for bad exclude pattern")
+	}
+	if !strings.Contains(err.Error(), "invalid exclude pattern") {
+		t.Errorf("error should mention invalid pattern, got: %v", err)
+	}
+}
+
+func TestLoadUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".handoff.yaml")
+	os.WriteFile(path, []byte("format: xml\n"), 0644)
+	os.Chmod(path, 0000)
+	t.Cleanup(func() { os.Chmod(path, 0644) })
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("Load should return error for unreadable file")
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Format != "markdown" {
+		t.Errorf("Format = %q, want %q", cfg.Format, "markdown")
+	}
+	if cfg.Output != "HANDOFF.md" {
+		t.Errorf("Output = %q, want %q", cfg.Output, "HANDOFF.md")
+	}
+	if cfg.Depth != 3 {
+		t.Errorf("Depth = %d, want 3", cfg.Depth)
+	}
+	if cfg.Files != nil {
+		t.Error("Files should be nil by default")
+	}
+	if cfg.Exclude != nil {
+		t.Error("Exclude should be nil by default")
 	}
 }

--- a/internal/differ/differ_test.go
+++ b/internal/differ/differ_test.go
@@ -52,3 +52,110 @@ func TestCompareRemoved(t *testing.T) {
 		}
 	}
 }
+
+func TestCompareExtraFiles(t *testing.T) {
+	parsed := &parser.ParsedHandoff{
+		Extra: map[string]string{
+			"NOTES.md":  "old notes",
+			"OLD.md":    "only in parsed",
+		},
+	}
+	current := &collector.ProjectFiles{
+		Extra: map[string]string{
+			"NOTES.md": "new notes",
+			"NEW.md":   "only in current",
+		},
+	}
+
+	diffs := Compare(parsed, current)
+
+	expected := map[string]string{
+		"Vision":   "unchanged", // both empty
+		"Plan":     "unchanged",
+		"Lessons":  "unchanged",
+		"NOTES.md": "changed",
+		"OLD.md":   "removed",
+		"NEW.md":   "added",
+	}
+
+	for _, d := range diffs {
+		want, ok := expected[d.Name]
+		if !ok {
+			t.Errorf("unexpected diff entry %q", d.Name)
+			continue
+		}
+		if d.Status != want {
+			t.Errorf("%s: Status = %q, want %q", d.Name, d.Status, want)
+		}
+	}
+}
+
+func TestCompareBothEmpty(t *testing.T) {
+	parsed := &parser.ParsedHandoff{}
+	current := &collector.ProjectFiles{}
+
+	diffs := Compare(parsed, current)
+	for _, d := range diffs {
+		if d.Status != "unchanged" {
+			t.Errorf("%s: Status = %q, want %q", d.Name, d.Status, "unchanged")
+		}
+	}
+}
+
+func TestCompareWhitespaceNormalization(t *testing.T) {
+	// TrimSpace strips leading/trailing whitespace from the whole string,
+	// so surrounding whitespace differences should be normalized away
+	parsed := &parser.ParsedHandoff{
+		Vision: "\n  # Vision\nContent.  \n\n",
+	}
+	current := &collector.ProjectFiles{
+		Vision: "# Vision\nContent.",
+	}
+
+	diffs := Compare(parsed, current)
+	for _, d := range diffs {
+		if d.Name == "Vision" && d.Status != "unchanged" {
+			t.Errorf("Vision with surrounding whitespace diff: Status = %q, want %q", d.Status, "unchanged")
+		}
+	}
+
+	// Inner whitespace differences should be detected as "changed"
+	parsed2 := &parser.ParsedHandoff{
+		Vision: "# Vision\n Content.",
+	}
+	current2 := &collector.ProjectFiles{
+		Vision: "# Vision\nContent.",
+	}
+	diffs2 := Compare(parsed2, current2)
+	for _, d := range diffs2 {
+		if d.Name == "Vision" && d.Status != "changed" {
+			t.Errorf("Vision with inner whitespace diff: Status = %q, want %q", d.Status, "changed")
+		}
+	}
+}
+
+func TestCompareDeterministicOrder(t *testing.T) {
+	parsed := &parser.ParsedHandoff{
+		Extra: map[string]string{
+			"Z.md": "z",
+			"A.md": "a",
+			"M.md": "m",
+		},
+	}
+	current := &collector.ProjectFiles{
+		Extra: map[string]string{
+			"Z.md": "z",
+			"A.md": "a",
+			"M.md": "m",
+		},
+	}
+
+	diffs := Compare(parsed, current)
+	// First 3 should be Vision, Plan, Lessons, then extras sorted
+	extraDiffs := diffs[3:]
+	for i := 1; i < len(extraDiffs); i++ {
+		if extraDiffs[i-1].Name > extraDiffs[i].Name {
+			t.Errorf("extra diffs not sorted: %q before %q", extraDiffs[i-1].Name, extraDiffs[i].Name)
+		}
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -95,5 +96,105 @@ Not found.
 	}
 	if parsed.Lessons != "" {
 		t.Errorf("Lessons should be empty for 'Not found.', got %q", parsed.Lessons)
+	}
+}
+
+func TestParseHandoffExtraSections(t *testing.T) {
+	content := `# HANDOFF.md
+
+## Vision
+# Vision
+Build it.
+
+## Extra: NOTES.md
+# Notes
+Important notes here.
+
+## Extra: TODO.md
+- [ ] Do something.
+
+## Directory Structure
+` + "```\nrepo/\n```\n"
+
+	parsed, err := ParseHandoffMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseHandoffMarkdown failed: %v", err)
+	}
+
+	if parsed.Extra["NOTES.md"] != "# Notes\nImportant notes here." {
+		t.Errorf("Extra[NOTES.md] = %q", parsed.Extra["NOTES.md"])
+	}
+	if parsed.Extra["TODO.md"] != "- [ ] Do something." {
+		t.Errorf("Extra[TODO.md] = %q", parsed.Extra["TODO.md"])
+	}
+}
+
+func TestParseHandoffEmptyContent(t *testing.T) {
+	parsed, err := ParseHandoffMarkdown("")
+	if err != nil {
+		t.Fatalf("ParseHandoffMarkdown failed: %v", err)
+	}
+	if parsed.Vision != "" || parsed.Plan != "" || parsed.Lessons != "" {
+		t.Error("empty content should produce empty parsed result")
+	}
+	if len(parsed.Extra) != 0 {
+		t.Error("empty content should produce no extras")
+	}
+}
+
+func TestParseHandoffNestedHeaders(t *testing.T) {
+	content := `## Vision
+# My Vision
+## Overview
+This is a nested header that should be part of the body.
+## Another nested one
+More content.
+
+## Plan
+# Plan content.
+`
+
+	parsed, err := ParseHandoffMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseHandoffMarkdown failed: %v", err)
+	}
+
+	// Nested ## headers that aren't known sections should be preserved
+	if parsed.Vision == "" {
+		t.Error("Vision should not be empty")
+	}
+	if !strings.Contains(parsed.Vision, "## Overview") {
+		t.Error("nested ## headers should be preserved in body")
+	}
+	if !strings.Contains(parsed.Vision, "## Another nested one") {
+		t.Error("nested ## headers should be preserved in body")
+	}
+}
+
+func TestParseHandoffSkipSections(t *testing.T) {
+	content := `## Project
+- Branch: main @ abc1234
+
+## Vision
+Build it.
+
+## Current State
+### Recent Commits
+- abc1234 initial
+
+## Directory Structure
+` + "```\nrepo/\n```\n"
+
+	parsed, err := ParseHandoffMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseHandoffMarkdown failed: %v", err)
+	}
+
+	if parsed.Vision != "Build it." {
+		t.Errorf("Vision = %q", parsed.Vision)
+	}
+	// Project, Current State, Directory Structure should not appear in extra
+	if len(parsed.Extra) != 0 {
+		t.Errorf("skip sections should not appear in extra, got %v", parsed.Extra)
 	}
 }

--- a/internal/renderer/handoff.go
+++ b/internal/renderer/handoff.go
@@ -9,12 +9,14 @@ import (
 )
 
 // RenderHandoff generates HANDOFF content from a snapshot in the given format.
-func RenderHandoff(s *collector.Snapshot, format string) string {
+func RenderHandoff(s *collector.Snapshot, format string) (string, error) {
 	switch format {
 	case FormatXML:
-		return renderHandoffXML(s)
+		return renderHandoffXML(s), nil
+	case FormatMarkdown:
+		return renderHandoffMarkdown(s), nil
 	default:
-		return renderHandoffMarkdown(s)
+		return "", fmt.Errorf("unsupported format %q (valid: %s)", format, strings.Join(ValidFormats, ", "))
 	}
 }
 

--- a/internal/renderer/handoff_test.go
+++ b/internal/renderer/handoff_test.go
@@ -37,7 +37,10 @@ func TestRenderHandoffNoGit(t *testing.T) {
 		},
 		DirTree: "project/\n├── main.go\n└── go.mod",
 	}
-	result := RenderHandoff(s, FormatMarkdown)
+	result, err := RenderHandoff(s, FormatMarkdown)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
 
 	if !strings.Contains(result, "Git: Not available") {
 		t.Error("should show 'Git: Not available' for empty GitInfo")
@@ -54,7 +57,10 @@ func TestRenderHandoffNoGit(t *testing.T) {
 
 func TestRenderHandoff(t *testing.T) {
 	s := testSnapshot()
-	result := RenderHandoff(s, FormatMarkdown)
+	result, err := RenderHandoff(s, FormatMarkdown)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
 
 	checks := []string{
 		"# HANDOFF.md",
@@ -81,7 +87,10 @@ func TestRenderHandoff(t *testing.T) {
 
 func TestRenderHandoffXML(t *testing.T) {
 	s := testSnapshot()
-	result := RenderHandoff(s, FormatXML)
+	result, err := RenderHandoff(s, FormatXML)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
 
 	checks := []string{
 		"<handoff>",
@@ -114,7 +123,10 @@ func TestRenderHandoffXMLNoGit(t *testing.T) {
 		},
 		DirTree: "project/\n├── main.go\n└── go.mod",
 	}
-	result := RenderHandoff(s, FormatXML)
+	result, err := RenderHandoff(s, FormatXML)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
 
 	if strings.Contains(result, "<project>") {
 		t.Error("should not contain <project> section for empty GitInfo")
@@ -132,7 +144,10 @@ func TestRenderHandoffExtra(t *testing.T) {
 		"NOTES.md": "# Notes\nSome notes.",
 	}
 
-	md := RenderHandoff(s, FormatMarkdown)
+	md, err := RenderHandoff(s, FormatMarkdown)
+	if err != nil {
+		t.Fatalf("RenderHandoff markdown failed: %v", err)
+	}
 	if !strings.Contains(md, "## Extra: NOTES.md") {
 		t.Error("markdown should contain extra file section with 'Extra: ' prefix")
 	}
@@ -140,8 +155,91 @@ func TestRenderHandoffExtra(t *testing.T) {
 		t.Error("markdown should contain extra file content")
 	}
 
-	xml := RenderHandoff(s, FormatXML)
+	xml, err := RenderHandoff(s, FormatXML)
+	if err != nil {
+		t.Fatalf("RenderHandoff xml failed: %v", err)
+	}
 	if !strings.Contains(xml, `<extra name="NOTES.md">`) {
 		t.Error("xml should contain extra file tag")
+	}
+}
+
+func TestRenderHandoffInvalidFormat(t *testing.T) {
+	s := testSnapshot()
+	_, err := RenderHandoff(s, "json")
+	if err == nil {
+		t.Fatal("RenderHandoff should return error for invalid format")
+	}
+	if !strings.Contains(err.Error(), "unsupported format") {
+		t.Errorf("error should mention unsupported format, got: %v", err)
+	}
+}
+
+func TestRenderHandoffNoChanges(t *testing.T) {
+	s := testSnapshot()
+	s.Git.HasChanges = false
+	s.Git.DiffSummary = ""
+
+	result, err := RenderHandoff(s, FormatMarkdown)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
+
+	if !strings.Contains(result, "Uncommitted changes: no") {
+		t.Error("should show 'Uncommitted changes: no'")
+	}
+	if strings.Contains(result, "### Uncommitted Changes") {
+		t.Error("should not show diff section when no changes")
+	}
+}
+
+func TestRenderHandoffNoRemote(t *testing.T) {
+	s := testSnapshot()
+	s.Git.RemoteURL = ""
+
+	result, err := RenderHandoff(s, FormatMarkdown)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
+
+	if strings.Contains(result, "Repository:") {
+		t.Error("should not show Repository when RemoteURL is empty")
+	}
+	if !strings.Contains(result, "Branch: main") {
+		t.Error("should still show Branch")
+	}
+}
+
+func TestRenderHandoffEmptySnapshot(t *testing.T) {
+	s := &collector.Snapshot{
+		Timestamp: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		Git:       collector.GitInfo{},
+		Files:     collector.ProjectFiles{},
+		DirTree:   "project/",
+	}
+
+	md, err := RenderHandoff(s, FormatMarkdown)
+	if err != nil {
+		t.Fatalf("RenderHandoff failed: %v", err)
+	}
+	for _, section := range []string{"## Vision", "## Plan", "## Lessons"} {
+		if !strings.Contains(md, section) {
+			t.Errorf("missing section %q", section)
+		}
+	}
+	// All file sections should show "Not found."
+	if strings.Count(md, "Not found.") != 3 {
+		t.Errorf("expected 3 'Not found.' markers, got %d", strings.Count(md, "Not found."))
+	}
+
+	xml, err := RenderHandoff(s, FormatXML)
+	if err != nil {
+		t.Fatalf("RenderHandoff XML failed: %v", err)
+	}
+	// Empty files should not produce XML sections
+	for _, tag := range []string{"<vision>", "<plan>", "<lessons>"} {
+		if strings.Contains(xml, tag) {
+			t.Errorf("empty content should not produce %s tag", tag)
+		}
 	}
 }

--- a/internal/renderer/prompt.go
+++ b/internal/renderer/prompt.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/kwrkb/repo-hand-off/internal/collector"
@@ -11,13 +12,28 @@ const (
 	FormatXML      = "xml"
 )
 
+// ValidFormats contains all supported output format names.
+var ValidFormats = []string{FormatMarkdown, FormatXML}
+
+// IsValidFormat returns true if the given format string is supported.
+func IsValidFormat(format string) bool {
+	for _, f := range ValidFormats {
+		if f == format {
+			return true
+		}
+	}
+	return false
+}
+
 // RenderPrompt generates an AI-ready prompt from a snapshot.
-func RenderPrompt(s *collector.Snapshot, format string) string {
+func RenderPrompt(s *collector.Snapshot, format string) (string, error) {
 	switch format {
 	case FormatXML:
-		return renderPromptXML(s)
+		return renderPromptXML(s), nil
+	case FormatMarkdown:
+		return renderPromptMarkdown(s), nil
 	default:
-		return renderPromptMarkdown(s)
+		return "", fmt.Errorf("unsupported format %q (valid: %s)", format, strings.Join(ValidFormats, ", "))
 	}
 }
 
@@ -29,7 +45,8 @@ func renderPromptMarkdown(s *collector.Snapshot) string {
 	b.WriteString("Below is the current state of the project. ")
 	b.WriteString("Read it carefully, then continue development based on the plan and current state.\n\n")
 	b.WriteString("---\n\n")
-	b.WriteString(RenderHandoff(s, FormatMarkdown))
+	handoff, _ := RenderHandoff(s, FormatMarkdown) // format is hardcoded, cannot fail
+	b.WriteString(handoff)
 
 	return b.String()
 }

--- a/internal/renderer/prompt_test.go
+++ b/internal/renderer/prompt_test.go
@@ -17,7 +17,10 @@ func TestRenderPromptXMLNoGit(t *testing.T) {
 		},
 		DirTree: "project/\n├── main.go\n└── go.mod",
 	}
-	result := RenderPrompt(s, "xml")
+	result, err := RenderPrompt(s, "xml")
+	if err != nil {
+		t.Fatalf("RenderPrompt failed: %v", err)
+	}
 
 	if strings.Contains(result, "<project>") {
 		t.Error("should not contain <project> section for empty GitInfo")
@@ -31,7 +34,10 @@ func TestRenderPromptXMLNoGit(t *testing.T) {
 
 func TestRenderPromptMarkdown(t *testing.T) {
 	s := testSnapshot()
-	result := RenderPrompt(s, "markdown")
+	result, err := RenderPrompt(s, "markdown")
+	if err != nil {
+		t.Fatalf("RenderPrompt failed: %v", err)
+	}
 
 	if !strings.Contains(result, "# Project Handoff Context") {
 		t.Error("markdown prompt should contain header")
@@ -43,7 +49,10 @@ func TestRenderPromptMarkdown(t *testing.T) {
 
 func TestRenderPromptXML(t *testing.T) {
 	s := testSnapshot()
-	result := RenderPrompt(s, "xml")
+	result, err := RenderPrompt(s, "xml")
+	if err != nil {
+		t.Fatalf("RenderPrompt failed: %v", err)
+	}
 
 	checks := []string{
 		"<handoff>",
@@ -58,6 +67,35 @@ func TestRenderPromptXML(t *testing.T) {
 	for _, check := range checks {
 		if !strings.Contains(result, check) {
 			t.Errorf("xml prompt missing %q", check)
+		}
+	}
+}
+
+func TestRenderPromptInvalidFormat(t *testing.T) {
+	s := testSnapshot()
+	_, err := RenderPrompt(s, "yaml")
+	if err == nil {
+		t.Fatal("RenderPrompt should return error for invalid format")
+	}
+	if !strings.Contains(err.Error(), "unsupported format") {
+		t.Errorf("error should mention unsupported format, got: %v", err)
+	}
+}
+
+func TestIsValidFormat(t *testing.T) {
+	tests := []struct {
+		format string
+		valid  bool
+	}{
+		{"markdown", true},
+		{"xml", true},
+		{"json", false},
+		{"", false},
+		{"MARKDOWN", false},
+	}
+	for _, tt := range tests {
+		if got := IsValidFormat(tt.format); got != tt.valid {
+			t.Errorf("IsValidFormat(%q) = %v, want %v", tt.format, got, tt.valid)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `RenderHandoff` / `RenderPrompt` の戻り値を `(string, error)` に変更し、不正な format 指定時にエラーを返すように（以前はサイレントに markdown フォールバック）
- `config.Load` の YAML パースエラーにコンテキストメッセージを付与
- 全 internal パッケージに対してエッジケーステストを追加（+578行）
- カバレッジ: config/differ/parser/renderer が 100%、collector が 87.9%

## Test plan

- [x] `go test ./...` 全パス
- [x] `go build ./cmd/handoff` ビルド成功
- [x] 不正 format でエラーが返ることを確認（TestRenderHandoffInvalidFormat, TestRenderPromptInvalidFormat）
- [x] 不正 YAML でコンテキスト付きエラーが返ることを確認（TestLoadInvalidYAML）

🤖 Generated with [Claude Code](https://claude.com/claude-code)