### PR TITLE
fix: Go バージョンを 1.25.8 に更新（GO-2026-4602 対応）

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kwrkb/repo-hand-off
 
-go 1.22
+go 1.25.8
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect


### PR DESCRIPTION
## Summary

- `go.mod` の Go バージョンを `1.22` → `1.25.8` に更新
- `os` パッケージの脆弱性 GO-2026-4602（`os.ReadDir` 経由の FileInfo Root 脱出）を解消

## Test plan

- [x] `go test ./...` 全パス
- [x] `go vet ./...` 全パス

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)